### PR TITLE
First stab at expanding to support other languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 Gitbook Plugin for [Prism](http://prismjs.com/)
 ==============
 
-Currently only supports JavaScript.  
-Pull requests to fix this are welcome.
-
 <table>
   <tr>
     <td>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "cheerio": "^0.19.0",
+    "prism-languages": "^0.1.3",
     "prismjs": "0.0.1"
   }
 }


### PR DESCRIPTION
This assumes that the language is passed through the code tag class. If gitbook relies on marked, this should work. It hasn't been tested, though.

If someone wants to give this a go, great. Ideally we would have a couple of test cases around covering the bases.

Closes #1.
