### PR TITLE
Plugin upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,23 @@ Gitbook Plugin for [Prism](http://prismjs.com/)
 
 Add the plugin to your `book.json`, and disable default GitBook code highlighting:
 
-```
+```json
 {
   "plugins": ["prism", "-highlight"]
+}
+```
+
+## Options
+
+Override default styles.  All css files must reside in the same folder.
+
+```json
+"pluginsConfig": {  
+  "prism": {
+    "css": [
+      "prismjs/themes/prism-solarizedlight.css"
+    ]
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,34 +1,65 @@
 var Prism = require('prismjs');
-var languages = require('prism-languages');
+var languages =  require('prismjs').languages;
 var path = require('path');
-
-var prismCSS = require.resolve('prismjs/themes/prism.css');
 
 var DEFAULT_LANGUAGE = 'markup';
 var MAP_LANGUAGES = {
   'py': 'python',
   'js': 'javascript',
-  'json': 'javascript',
   'rb': 'ruby',
   'csharp': 'cs',
   'html': 'markup'
 };
 
-var assets = {
-  assets: path.dirname(prismCSS),
-  css: [path.basename(prismCSS)]
-};
+function getAssets() {
+
+  var book = this;
+
+  var cssFiles = this.config.get('pluginsConfig.prism.css', []);
+  var cssFolder = null;
+  var cssNames = [];
+
+  if(cssFiles.length === 0) {
+    cssFiles.push('prismjs/themes/prism.css');
+  }
+
+  cssFiles.forEach(function(cssFile) {
+    var cssPath = require.resolve(cssFile);
+    cssFolder = path.dirname(cssPath);
+    cssName = path.basename(cssPath);
+    cssNames.push(cssName);
+  });
+
+  var assets = {
+    assets: cssFolder,
+    css: cssNames
+  };
+
+  return assets;
+}
 
 module.exports = {
-  book: assets,
-  ebook: assets,
+  book: getAssets,
+  ebook: getAssets,
   blocks: {
     code: function(block) {
+
       var highlighted = '';
 
       // Normalize language id
       var lang = block.kwargs.language || DEFAULT_LANGUAGE;
       lang = MAP_LANGUAGES[lang] || lang;
+
+      // Try and find the language definition in components folder
+      if (!languages[lang]) {
+        try {
+          require('prismjs/components/prism-' + lang + '.js');
+        }catch(e) {
+          console.warn('Failed to load prism syntax: '+ lang);
+          console.warn(e);
+        }
+      }
+
       if (!languages[lang]) lang = DEFAULT_LANGUAGE;
 
       // Check against html, prism "markup" works for this

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/gaearon/gitbook-plugin-prism/issues"
   },
   "dependencies": {
-    "prismjs": "0.0.1",
-    "prism-languages": "^0.1.3"
+    "prismjs": "1.5.1"
   }
 }


### PR DESCRIPTION
- deprecate `prism-languages` in favor of `require('prismjs').languages`
- fix json syntax highlighting by using native json highlighter
- automatically load syntax definitions from `prismjs/components` folder
- upgrade Prism.js to `v1.5.1`
- Closes #6. Ability to introduce custom styles for syntax highlighting in `book.json`.   Defaults to `prismjs/themes/prism.css`

``` json
"pluginsConfig": {  
  "prism": {
    "css": [
      "prismjs/themes/prism-solarizedlight.css"
    ]
  }
}
```
