### PR TITLE
Fix importing language definition with dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,18 @@ var MAP_LANGUAGES = {
   'html': 'markup'
 };
 
+// Base languages syntaxes, extended by other syntaxes, need to be
+// required before all.
+var PRELUDE = ['clike', 'javascript', 'markup', 'c', 'ruby', 'css'];
+PRELUDE.map(requireSyntax);
+
+/**
+ * Load the syntax definition for a language id
+ */
+function requireSyntax(lang) {
+    require('prismjs/components/prism-' + lang + '.js');
+}
+
 function getAssets() {
 
   var cssFiles = this.config.get('pluginsConfig.prism.css', []);
@@ -61,7 +73,7 @@ module.exports = {
       // Try and find the language definition in components folder
       if (!languages[lang]) {
         try {
-          require('prismjs/components/prism-' + lang + '.js');
+            requireSyntax(lang);
         } catch (e) {
           console.warn('Failed to load prism syntax: ' + lang);
           console.warn(e);

--- a/index.js
+++ b/index.js
@@ -14,16 +14,20 @@ var MAP_LANGUAGES = {
   'html': 'markup'
 };
 
-// Base languages syntaxes, extended by other syntaxes, need to be
-// required before all.
-var PRELUDE = ['clike', 'javascript', 'markup', 'c', 'ruby', 'css'];
+// Base languages syntaxes (as of prism@1.6.0), extended by other syntaxes.
+// They need to be required before the others.
+var PRELUDE = [
+  'clike', 'javascript', 'markup', 'c', 'ruby', 'css', 'previewer-base', 'toolbar',
+  // The following depends on previous ones
+  'java', 'php'
+];
 PRELUDE.map(requireSyntax);
 
 /**
  * Load the syntax definition for a language id
  */
 function requireSyntax(lang) {
-    require('prismjs/components/prism-' + lang + '.js');
+  require('prismjs/components/prism-' + lang + '.js');
 }
 
 function getAssets() {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var MAP_LANGUAGES = {
 // Base languages syntaxes (as of prism@1.6.0), extended by other syntaxes.
 // They need to be required before the others.
 var PRELUDE = [
-  'clike', 'javascript', 'markup', 'c', 'ruby', 'css', 'previewer-base', 'toolbar',
+  'clike', 'javascript', 'markup', 'c', 'ruby', 'css',
   // The following depends on previous ones
   'java', 'php'
 ];


### PR DESCRIPTION
```
Failed to load prism syntax: cpp
TypeError: Cannot set property 'keyword' of undefined
```

Currently, the plugin seems to fail with when the language syntax used has a dependency (its Prism definition extends another syntax), such as C++ that extends C, the plugin fails to load the syntax because it does not load its dependencies.

This PR requires at startup a "prelude" of syntax definitions, the few ones that are extended. It allows to use syntax such as `cpp`, `java`, `go`...

An alternative is to require dependencies dynamically. But this is not straight feasible, since Prism [does not export the components dependencies list](https://github.com/PrismJS/prism/issues/972).

Related https://github.com/gaearon/gitbook-plugin-prism/issues/16