### PR TITLE
Add alias "sh" for bash syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var MAP_LANGUAGES = {
   'js': 'javascript',
   'rb': 'ruby',
   'cs': 'csharp',
+  'sh': 'bash',
   'html': 'markup'
 };
 


### PR DESCRIPTION
Prism doesn't support the `sh` syntax prefix, which is ubiquitous in GitHub Flavored Markdown readmes. 

This commit aliases the `bash` syntax to `sh` to better support generating gitbooks out of documentation out in the wild.