### PR TITLE
Add pluginsConfig.prism.lang to add support for custom syntax prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ Override default styles.  All css files must reside in the same folder.
 #### Xonokai <small>`syntax-highlighting/assets/css/prism/prism-xonokai.css`</small>
 ![Google Light](http://i.imgur.com/fPjEEv8.png)
 
+### Syntax aliasing
+
+To support non-standard syntax prefixes, you can alias existing prefixes:
+```json
+"pluginsConfig": {  
+  "prism": {
+    "lang": {
+      "flow": "typescript"
+    }
+  }
+}
+```
+
 ## Credits
 
 Originally based on https://github.com/spricity/google_code_prettify.

--- a/index.js
+++ b/index.js
@@ -69,10 +69,11 @@ module.exports = {
     code: function(block) {
 
       var highlighted = '';
+      var userDefined = this.config.get('pluginsConfig.prism.lang', {});
 
       // Normalize language id
       var lang = block.kwargs.language || DEFAULT_LANGUAGE;
-      lang = MAP_LANGUAGES[lang] || lang;
+      lang = userDefined[lang] || MAP_LANGUAGES[lang] || lang;
 
       // Try and find the language definition in components folder
       if (!languages[lang]) {


### PR DESCRIPTION
Follow-up on https://github.com/gaearon/gitbook-plugin-prism/pull/19 which proposed to add support for the `sh` syntax by aliasing it to `bash`.

This commit adds support for `pluginsConfig.prism.lang` map, so book creators can support less common syntax prefixes without having to fork this plugin.

This feature is important when using Gitbook to generate documentation sites out of existing docs out in the wild, without having to tailor the documentation to Prism-supported format.