### PR TITLE
warnfix(gitbook v3.*):update gitbook version validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function getConfig(context, property, defaultValue) {
 
 function isEbook(book) {
   // 2.x
-  if (book.options && book.options.generator) {
+  if (/^2+\.\d+\.\d+$/.test(book.gitbook.version)) {
     return book.options.generator === 'ebook';
   }
 


### PR DESCRIPTION
use 
```javascript
if(book.options && book.options.generator)
``` 
to confirm gitbook version, will get a warn info 
```bash
warn: "options.generator" property is deprecated, use "output.name" instead
``` 
in terminal #36 